### PR TITLE
Transformer 4.45.0 support

### DIFF
--- a/QQQ/gptq/models/qwen2.py
+++ b/QQQ/gptq/models/qwen2.py
@@ -328,6 +328,9 @@ class QuantizedQwen2Model(Qwen2Model):
         self._attn_implementation = config._attn_implementation
         self.norm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
+        # added for transformer>=4.45.0
+        self.rotary_emb = Qwen2RotaryEmbedding(config=config)
+
         self.gradient_checkpointing = False
         # Initialize weights and apply final processing
         self.post_init()

--- a/QQQ/smooth/migration/migration_qwen2.py
+++ b/QQQ/smooth/migration/migration_qwen2.py
@@ -198,10 +198,7 @@ class MigratorBase(nn.Module):
             .view(B, N, self.extra_dict["num_key_value_heads"], head_dim)
             .transpose(1, 2)
         )
-        cos, sin = (
-            self.extra_dict["cos_cached"],
-            self.extra_dict["sin_cached"],
-        )
+        cos, sin = self.extra_dict['rotary_emb'](v, self.extra_dict["position_ids"])
         q, k = qwen2.apply_rotary_pos_emb(
             q, k, cos, sin, self.extra_dict["position_ids"]
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.38.2
+transformers==4.45.0
 datasets==2.16.1
 easydict
 accelerate


### PR DESCRIPTION
1. Transformer 4.45.0 is supported. Llama  model is not needed to be modified, but  some fixes are needed for qwen2 model.
2. These changes can be used to support for qwen2-vl, the associated files will be pushed  after this pr is merged.